### PR TITLE
Fix Watcher translation keys on error prop missing

### DIFF
--- a/x-pack/plugins/watcher/server/models/action/action.js
+++ b/x-pack/plugins/watcher/server/models/action/action.js
@@ -29,7 +29,7 @@ export class Action {
   static fromUpstreamJson(json, options = { throwExceptions: {} }) {
     if (!json.id) {
       throw badRequest(
-        i18n.translate('xpack.watcher.models.actionStatus.absenceOfIdPropertyBadRequestMessage', {
+        i18n.translate('xpack.watcher.models.actionStatus.idPropertyMissingBadRequestMessage', {
           defaultMessage: 'json argument must contain an {id} property',
           values: {
             id: 'id'
@@ -40,7 +40,7 @@ export class Action {
 
     if (!json.actionJson) {
       throw badRequest(
-        i18n.translate('xpack.watcher.models.action.absenceOfActionJsonPropertyBadRequestMessage', {
+        i18n.translate('xpack.watcher.models.action.actionJsonPropertyMissingBadRequestMessage', {
           defaultMessage: 'json argument must contain an {actionJson} property',
           values: {
             actionJson: 'actionJson'

--- a/x-pack/plugins/watcher/server/models/action/base_action.js
+++ b/x-pack/plugins/watcher/server/models/action/base_action.js
@@ -37,7 +37,7 @@ export class BaseAction {
   static getPropsFromUpstreamJson(json) {
     if (!json.id) {
       throw badRequest(
-        i18n.translate('xpack.watcher.models.baseAction.absenceOfIdPropertyBadRequestMessage', {
+        i18n.translate('xpack.watcher.models.baseAction.idPropertyMissingBadRequestMessage', {
           defaultMessage: 'json argument must contain an {id} property',
           values: {
             id: 'id'

--- a/x-pack/plugins/watcher/server/models/action/email_action.js
+++ b/x-pack/plugins/watcher/server/models/action/email_action.js
@@ -97,7 +97,7 @@ export class EmailAction extends BaseAction {
     const errors = [];
 
     if (!json.email) {
-      const message = i18n.translate('xpack.watcher.models.emailAction.absenceOfActionJsonEmailPropertyBadRequestMessage', {
+      const message = i18n.translate('xpack.watcher.models.emailAction.actionJsonEmailPropertyMissingBadRequestMessage', {
         defaultMessage: 'json argument must contain an {actionJsonEmail} property',
         values: {
           actionJsonEmail: 'actionJson.email'
@@ -113,7 +113,7 @@ export class EmailAction extends BaseAction {
     }
 
     if (!json.email.to) {
-      const message = i18n.translate('xpack.watcher.models.emailAction.absenceOfActionJsonEmailToPropertyBadRequestMessage', {
+      const message = i18n.translate('xpack.watcher.models.emailAction.actionJsonEmailToPropertyMissingBadRequestMessage', {
         defaultMessage: 'json argument must contain an {actionJsonEmailTo} property',
         values: {
           actionJsonEmailTo: 'actionJson.email.to'

--- a/x-pack/plugins/watcher/server/models/action/logging_action.js
+++ b/x-pack/plugins/watcher/server/models/action/logging_action.js
@@ -71,7 +71,7 @@ export class LoggingAction extends BaseAction {
     if (!json.logging) {
       errors.push({
         code: ERROR_CODES.ERR_PROP_MISSING,
-        message: i18n.translate('xpack.watcher.models.loggingAction.absenceOfActionJsonLoggingPropertyBadRequestMessage', {
+        message: i18n.translate('xpack.watcher.models.loggingAction.actionJsonLoggingPropertyMissingBadRequestMessage', {
           defaultMessage: 'json argument must contain an {actionJsonLogging} property',
           values: {
             actionJsonLogging: 'actionJson.logging'
@@ -85,7 +85,7 @@ export class LoggingAction extends BaseAction {
     if (!json.logging.text) {
       errors.push({
         code: ERROR_CODES.ERR_PROP_MISSING,
-        message: i18n.translate('xpack.watcher.models.loggingAction.absenceOfActionJsonLoggingTextPropertyBadRequestMessage', {
+        message: i18n.translate('xpack.watcher.models.loggingAction.actionJsonLoggingTextPropertyMissingBadRequestMessage', {
           defaultMessage: 'json argument must contain an {actionJsonLoggingText} property',
           values: {
             actionJsonLoggingText: 'actionJson.logging.text'

--- a/x-pack/plugins/watcher/server/models/action/slack_action.js
+++ b/x-pack/plugins/watcher/server/models/action/slack_action.js
@@ -80,7 +80,7 @@ export class SlackAction extends BaseAction {
     if (!json.slack) {
       errors.push({
         code: ERROR_CODES.ERR_PROP_MISSING,
-        message: i18n.translate('xpack.watcher.models.slackAction.absenceOfActionJsonSlackPropertyBadRequestMessage', {
+        message: i18n.translate('xpack.watcher.models.slackAction.actionJsonSlackPropertyMissingBadRequestMessage', {
           defaultMessage: 'json argument must contain an {actionJsonSlack} property',
           values: {
             actionJsonSlack: 'actionJson.slack'
@@ -94,7 +94,7 @@ export class SlackAction extends BaseAction {
     if (!json.slack.message) {
       errors.push({
         code: ERROR_CODES.ERR_PROP_MISSING,
-        message: i18n.translate('xpack.watcher.models.slackAction.absenceOfActionJsonSlackMessagePropertyBadRequestMessage', {
+        message: i18n.translate('xpack.watcher.models.slackAction.actionJsonSlackMessagePropertyMissingBadRequestMessage', {
           defaultMessage: 'json argument must contain an {actionJsonSlackMessage} property',
           values: {
             actionJsonSlackMessage: 'actionJson.slack.message'

--- a/x-pack/plugins/watcher/server/models/action/unknown_action.js
+++ b/x-pack/plugins/watcher/server/models/action/unknown_action.js
@@ -67,7 +67,7 @@ export class UnknownAction extends BaseAction {
     if (!json.actionJson) {
       errors.push({
         code: ERROR_CODES.ERR_PROP_MISSING,
-        message: i18n.translate('xpack.watcher.models.unknownAction.absenceOfActionJsonPropertyBadRequestMessage', {
+        message: i18n.translate('xpack.watcher.models.unknownAction.actionJsonPropertyMissingBadRequestMessage', {
           defaultMessage: 'json argument must contain an {actionJson} property',
           values: {
             actionJson: 'actionJson'

--- a/x-pack/plugins/watcher/server/models/action_status/action_status.js
+++ b/x-pack/plugins/watcher/server/models/action_status/action_status.js
@@ -103,7 +103,7 @@ export class ActionStatus {
   static fromUpstreamJson(json) {
     if (!json.id) {
       throw badRequest(
-        i18n.translate('xpack.watcher.models.actionStatus.absenceOfIdPropertyBadRequestMessage', {
+        i18n.translate('xpack.watcher.models.actionStatus.idPropertyMissingBadRequestMessage', {
           defaultMessage: 'json argument must contain an {id} property',
           values: {
             id: 'id'
@@ -113,7 +113,7 @@ export class ActionStatus {
     }
     if (!json.actionStatusJson) {
       throw badRequest(
-        i18n.translate('xpack.watcher.models.actionStatus.absenceOfActionStatusJsonPropertyBadRequestMessage', {
+        i18n.translate('xpack.watcher.models.actionStatus.actionStatusJsonPropertyMissingBadRequestMessage', {
           defaultMessage: 'json argument must contain an {actionStatusJson} property',
           values: {
             actionStatusJson: 'actionStatusJson'

--- a/x-pack/plugins/watcher/server/models/fields/fields.js
+++ b/x-pack/plugins/watcher/server/models/fields/fields.js
@@ -54,7 +54,7 @@ export class Fields {
   static fromUpstreamJson(json) {
     if (!json.fields) {
       throw badRequest(
-        i18n.translate('xpack.watcher.models.fields.absenceOfFieldsPropertyBadRequestMessage', {
+        i18n.translate('xpack.watcher.models.fields.fieldsPropertyMissingBadRequestMessage', {
           defaultMessage: 'json argument must contain a {fields} property',
           values: {
             fields: 'fields'

--- a/x-pack/plugins/watcher/server/models/watch/base_watch.js
+++ b/x-pack/plugins/watcher/server/models/watch/base_watch.js
@@ -93,7 +93,7 @@ export class BaseWatch {
   static getPropsFromUpstreamJson(json, options) {
     if (!json.id) {
       throw badRequest(
-        i18n.translate('xpack.watcher.models.baseWatch.absenceOfIdPropertyBadRequestMessage', {
+        i18n.translate('xpack.watcher.models.baseWatch.idPropertyMissingBadRequestMessage', {
           defaultMessage: 'json argument must contain an {id} property',
           values: {
             id: 'id'
@@ -103,7 +103,7 @@ export class BaseWatch {
     }
     if (!json.watchJson) {
       throw badRequest(
-        i18n.translate('xpack.watcher.models.baseWatch.absenceOfWatchJsonPropertyBadRequestMessage', {
+        i18n.translate('xpack.watcher.models.baseWatch.watchJsonPropertyMissingBadRequestMessage', {
           defaultMessage: 'json argument must contain a {watchJson} property',
           values: {
             watchJson: 'watchJson'
@@ -113,7 +113,7 @@ export class BaseWatch {
     }
     if (!json.watchStatusJson) {
       throw badRequest(
-        i18n.translate('xpack.watcher.models.baseWatch.absenceOfWatchStatusJsonPropertyBadRequestMessage', {
+        i18n.translate('xpack.watcher.models.baseWatch.watchStatusJsonPropertyMissingBadRequestMessage', {
           defaultMessage: 'json argument must contain a {watchStatusJson} property',
           values: {
             watchStatusJson: 'watchStatusJson'

--- a/x-pack/plugins/watcher/server/models/watch/watch.js
+++ b/x-pack/plugins/watcher/server/models/watch/watch.js
@@ -27,7 +27,7 @@ export class Watch {
   static fromDownstreamJson(json) {
     if (!json.type) {
       throw badRequest(
-        i18n.translate('xpack.watcher.models.watch.absenceOfTypePropertyBadRequestMessage', {
+        i18n.translate('xpack.watcher.models.watch.typePropertyMissingBadRequestMessage', {
           defaultMessage: 'json argument must contain an {type} property',
           values: {
             type: 'type'
@@ -39,7 +39,7 @@ export class Watch {
     const WatchType = WatchTypes[json.type];
     if (!WatchType) {
       throw badRequest(
-        i18n.translate('xpack.watcher.models.watch.unknownJsonTypeAttemptedToLoadBadRequestMessage', {
+        i18n.translate('xpack.watcher.models.watch.unknownWatchTypeLoadingAttemptBadRequestMessage', {
           defaultMessage: 'Attempted to load unknown type {jsonType}',
           values: { jsonType: json.type }
         }),
@@ -53,7 +53,7 @@ export class Watch {
   static fromUpstreamJson(json, options) {
     if (!json.watchJson) {
       throw badRequest(
-        i18n.translate('xpack.watcher.models.watch.absenceOfWatchJsonPropertyBadRequestMessage', {
+        i18n.translate('xpack.watcher.models.watch.watchJsonPropertyMissingBadRequestMessage', {
           defaultMessage: 'json argument must contain a {watchJson} property',
           values: {
             watchJson: 'watchJson'

--- a/x-pack/plugins/watcher/server/models/watch_history_item/watch_history_item.js
+++ b/x-pack/plugins/watcher/server/models/watch_history_item/watch_history_item.js
@@ -39,7 +39,7 @@ export class WatchHistoryItem {
   static fromUpstreamJson(json, opts) {
     if (!json.id) {
       throw badRequest(
-        i18n.translate('xpack.watcher.models.watchHistoryItem.absenceOfIdPropertyBadRequestMessage', {
+        i18n.translate('xpack.watcher.models.watchHistoryItem.idPropertyMissingBadRequestMessage', {
           defaultMessage: 'json argument must contain an {id} property',
           values: {
             id: 'id'
@@ -49,7 +49,7 @@ export class WatchHistoryItem {
     }
     if (!json.watchId) {
       throw badRequest(
-        i18n.translate('xpack.watcher.models.watchHistoryItem.absenceOfWatchIdPropertyBadRequestMessage', {
+        i18n.translate('xpack.watcher.models.watchHistoryItem.watchIdPropertyMissingBadRequestMessage', {
           defaultMessage: 'json argument must contain a {watchId} property',
           values: {
             watchId: 'watchId'
@@ -59,7 +59,7 @@ export class WatchHistoryItem {
     }
     if (!json.watchHistoryItemJson) {
       throw badRequest(
-        i18n.translate('xpack.watcher.models.watchHistoryItem.absenceOfWatchHistoryItemJsonPropertyBadRequestMessage', {
+        i18n.translate('xpack.watcher.models.watchHistoryItem.watchHistoryItemJsonPropertyMissingBadRequestMessage', {
           defaultMessage: 'json argument must contain a {watchHistoryItemJson} property',
           values: {
             watchHistoryItemJson: 'watchHistoryItemJson'

--- a/x-pack/plugins/watcher/server/models/watch_status/watch_status.js
+++ b/x-pack/plugins/watcher/server/models/watch_status/watch_status.js
@@ -140,7 +140,7 @@ export class WatchStatus {
   static fromUpstreamJson(json) {
     if (!json.id) {
       throw badRequest(
-        i18n.translate('xpack.watcher.models.watchStatus.absenceOfIdPropertyBadRequestMessage', {
+        i18n.translate('xpack.watcher.models.watchStatus.idPropertyMissingBadRequestMessage', {
           defaultMessage: 'json argument must contain an {id} property',
           values: {
             id: 'id'
@@ -150,7 +150,7 @@ export class WatchStatus {
     }
     if (!json.watchStatusJson) {
       throw badRequest(
-        i18n.translate('xpack.watcher.models.watchStatus.absenceOfWatchStatusJsonPropertyBadRequestMessage', {
+        i18n.translate('xpack.watcher.models.watchStatus.watchStatusJsonPropertyMissingBadRequestMessage', {
           defaultMessage: 'json argument must contain a {watchStatusJson} property',
           values: {
             watchStatusJson: 'watchStatusJson'


### PR DESCRIPTION
## Summary

The x-pack Watcher plugin has some weird translation id. This PR reword the translation IDs for the error messages when a property is missing on an object.